### PR TITLE
UTF decoding, Hikari dispersion, additional refactor

### DIFF
--- a/ZemaxGlass.py
+++ b/ZemaxGlass.py
@@ -678,11 +678,21 @@ def parse_glass_file(filename):
     glass_catalog : dict
         The dictionary containing glass data for all classes in the file.
     '''
-
-    f = open(filename, 'r', encoding='latin1')
     glass_catalog = {}
+    encodings = ['utf-16', 'utf-8', 'utf-8-sig', 'iso-8859-1', 'latin1']
 
-    for line in f:
+    for decode in encodings:
+        try:
+            with open(filename, 'r', encoding=decode) as file:
+                inpt = file.read()
+        except UnicodeError:
+            pass
+        else:
+            break
+
+    # print(f"{filename.split('/')[-1]:17s}   encoding: {decode}")
+
+    for line in inpt.splitlines():
         if not line.strip(): continue
         if line.startswith('CC '): continue
         if line.startswith('NM '):
@@ -739,9 +749,7 @@ def parse_glass_file(filename):
             else:
                 glass_catalog[glassname]['it']['thickness'].append(nan)
 
-    f.close()
-
-    return(glass_catalog)
+    return glass_catalog
 
 ## =========================
 def get_dispersion(glass, catalog, glass_rec, w, T=20.0, P=1.0113e5):

--- a/ZemaxGlass.py
+++ b/ZemaxGlass.py
@@ -691,6 +691,13 @@ def parse_glass_file(filename):
             break
 
     # print(f"{filename.split('/')[-1]:17s}   encoding: {decode}")
+    return parse_glass_input(inpt)
+
+
+## =============================================================================
+def parse_glass_input(inpt):
+
+    glass_catalog = {}
 
     for line in inpt.splitlines():
         if not line.strip(): continue

--- a/ZemaxGlass.py
+++ b/ZemaxGlass.py
@@ -857,6 +857,10 @@ def get_dispersion(glass, catalog, glass_rec, w, T=20.0, P=1.0113e5):
         formula_rhs = cd[0] + (cd[1] * w**2) + (cd[2] * w**-2) + (cd[3] * w**-4) + (cd[4] * w**-6) + \
                         (cd[5] * w**-8) + (cd[6] * w**4) + (cd[7] * w**6)
         indices = sqrt(formula_rhs)
+    elif (dispform == 13):  ## Hikari
+        formula_rhs = cd[0] + (cd[1] * w**2) + (cd[2] * w**4) + (cd[3] * w**-2) + (cd[4] * w**-4) + \
+                        (cd[5] * w**-6) + (cd[6] * w**-8) + (cd[7] * w**-10) + (cd[8] * w**-12)
+        indices = sqrt(formula_rhs)
     else:
         raise ValueError('Dispersion formula #' + str(dispform) + ' (for glass=' + glass + ' in catalog=' + catalog + ') is not a valid choice.')
 


### PR DESCRIPTION
1. I found that the hoya.agf file wasn't being read because it was encoded as UTF-16. I had similar problems reading .zmx files with ray-optics and implemented a similar, brute-force, solution here.
2. I found some Hikari glasses required a new dispersion formula. 
3. I'm working on reading .zar files that have .zmx and .agf data in them. Refactored to expose str input to the parser.