### PR TITLE
change version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ZemaxGlass"
 description = "Zemax glass (.agf) file reader"
 readme = "README.md"
-version = "2.0.0a4"
+version = "2.0.0"
 
 license = "MIT"
 license-files = ["LICENSE.txt",]


### PR DESCRIPTION
Hello Nathan,

I've removed the alpha designation on the version number in this pull request, version=2.0.0

In my OpticalGlass package, I currently reference ZemaxGlass via the appropriate node in GitHub. PyPi doesn't like this for reasons so I cannot release OpticalGlass to PyPi without a reference-able version of ZemaxGlass on PyPi. If you can merge this pull-request and update a ZemaxGlass build to PyPi using twine, that would be best for me. 

I really understand, though, if you have more important things on your plate and can't spare attention for this - just let me know. Plan B is something brute force like including ZemaxGlass.py and the AGF_files directory in the OpticalGlass distribution.

Let me know what works for you.

Regards,

Mike Hayford