### PR TITLE
Packaging update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["setuptools>=82.0.1", "setuptools-scm>=10.0.5"]
+requires = ["setuptools>=83.0.0", "setuptools-scm>=10.2.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "ZemaxGlass"
 description = "Zemax glass (.agf) file reader"
 readme = "README.md"
-version = "2.0.0"
+version = "2.0.1a1"
 
 license = "MIT"
 license-files = ["LICENSE.txt",]
@@ -30,9 +30,9 @@ keywords = [ "zemax", "glass", "spectra", "dispersion",]
 requires-python = ">=3.12"
 
 dependencies = [ 
-    "numpy>=2.4.6", 
-    "scipy>=1.17.1", 
-    "matplotlib>=3.10.9", 
+    "numpy>=2.5.1", 
+    "scipy>=1.18.0", 
+    "matplotlib>=3.11.1", 
     "cycler>=0.12.1",
 ]
 
@@ -55,7 +55,7 @@ include-package-data = true
 "" = "src"
 
 [tool.setuptools.package-data]
-data = [ "AGF_files/*", ]
+ZemaxGlass.AGF_files = ["*.agf", "*.AGF"]
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ZemaxGlass"
 description = "Zemax glass (.agf) file reader"
 readme = "README.md"
-version = "2.0.1a1"
+version = "2.0.1"
 
 license = "MIT"
 license-files = ["LICENSE.txt",]
@@ -30,9 +30,9 @@ keywords = [ "zemax", "glass", "spectra", "dispersion",]
 requires-python = ">=3.12"
 
 dependencies = [ 
-    "numpy>=2.5.1", 
-    "scipy>=1.18.0", 
-    "matplotlib>=3.11.1", 
+    "numpy>=2.4.6", 
+    "scipy>=1.17.1", 
+    "matplotlib>=3.10.9", 
     "cycler>=0.12.1",
 ]
 
@@ -53,9 +53,6 @@ include-package-data = true
 
 [tool.setuptools.package-dir]
 "" = "src"
-
-[tool.setuptools.package-data]
-ZemaxGlass.AGF_files = ["*.agf", "*.AGF"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
The pyproject.toml file was misconfigured and the AGF_files directory wasn't installed for some cases. The `setuptools` directive `include-package-data` will include everything managed in git under the "src" directory, both python and non-python files, using the tool `setuptools_scm`. An additional directive, package-data, was removed because 

1. it duplicated the `include-package-data` directive 
2. failed on some platforms (conda-forge) and not others (PyPI).

The version number was bumped to 2.0.1 to force use of this version.

If you could upload this new version to pypi I'd appreciate it.

Regards, Mike